### PR TITLE
Add external sources feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/test/*.js
+pnpm-lock.yaml

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.ExternalSourceError = void 0;
 exports.default = disposableEmailDetector;
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
@@ -24,12 +25,43 @@ const loadDomains = () => __awaiter(void 0, void 0, void 0, function* () {
     cachedDomains = disposableDomains;
     return disposableDomains;
 });
+class ExternalSourceError extends Error {
+    constructor(message = 'URL must be provided when loading from external source') {
+        super(message);
+        this.name = 'ExternalSourceError';
+        Object.setPrototypeOf(this, ExternalSourceError.prototype);
+    }
+}
+exports.ExternalSourceError = ExternalSourceError;
+const loadDomainsFromExternalSource = (_a) => __awaiter(void 0, [_a], void 0, function* ({ github, url }) {
+    if (cachedDomains)
+        return cachedDomains;
+    const URL = github ? "https://raw.githubusercontent.com/IntegerAlex/disposable-email-detector/refs/heads/main/index.json" : url;
+    if (!URL)
+        throw new ExternalSourceError();
+    console.info(`Loading disposable domains from ${URL}`);
+    try {
+        const response = yield fetch(URL);
+        const disposableDomains = yield response.json();
+        cachedDomains = disposableDomains;
+        return disposableDomains;
+    }
+    catch (error) {
+        throw new ExternalSourceError("Failed to load disposable domains from the provided URL");
+    }
+});
 // Function to detect disposable email addresses
-function disposableEmailDetector(email) {
+function disposableEmailDetector(email, options) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            // Load the list of disposable email domains from the index.json file
-            const disposableDomains = yield loadDomains();
+            let disposableDomains = [];
+            // Load from external source
+            if (options === null || options === void 0 ? void 0 : options.loadFromSource) {
+                disposableDomains = yield loadDomainsFromExternalSource(options.loadFromSource);
+            }
+            else {
+                disposableDomains = yield loadDomains();
+            }
             // Extract the domain from the email address
             const domain = email.split('@')[1].toLowerCase(); // Get the domain part of the email address and convert it to lowercase
             // Check if the domain is in the list of disposable domains 
@@ -41,6 +73,9 @@ function disposableEmailDetector(email) {
             }
             else if (error instanceof SyntaxError) {
                 console.error('Invalid JSON format in index.json. Please correct the file.');
+            }
+            else if (error instanceof ExternalSourceError) {
+                console.error(error.message);
             }
             else {
                 console.error('Unexpected error:', error);

--- a/index.ts
+++ b/index.ts
@@ -11,11 +11,48 @@ const loadDomains = async () => {
   return disposableDomains;
 }
 
+export class ExternalSourceError extends Error {
+  constructor(message: string = 'URL must be provided when loading from external source') {
+    super(message);
+    this.name = 'ExternalSourceError';
+    Object.setPrototypeOf(this, ExternalSourceError.prototype);
+  }
+}
+
+const loadDomainsFromExternalSource = async ({github, url}: LoadFromSource) => {
+    if (cachedDomains) return cachedDomains;
+    const URL = github ? "https://raw.githubusercontent.com/IntegerAlex/disposable-email-detector/refs/heads/main/index.json" : url;
+    if (!URL) throw new ExternalSourceError();
+    try {
+        const response = await fetch(URL);
+        const disposableDomains = await response.json();
+        cachedDomains = disposableDomains
+        return disposableDomains;
+    } catch (error) {
+        throw new ExternalSourceError("Failed to load disposable domains from the provided URL");
+    }
+}
+
+type LoadFromSource = {
+    github?: boolean;
+    url?: string;
+}
+
+type Options = {
+    loadFromSource?: LoadFromSource;
+}
+
 // Function to detect disposable email addresses
-export default async function disposableEmailDetector(email: string): Promise<boolean> {
+export default async function disposableEmailDetector(email: string, options?: Options): Promise<boolean> {
   try {
-    // Load the list of disposable email domains from the index.json file
-    const disposableDomains = await loadDomains();
+      let disposableDomains = [];
+    // Load from external source
+    if (options?.loadFromSource) {
+        disposableDomains = await loadDomainsFromExternalSource(options.loadFromSource);
+    } else {
+        disposableDomains = await loadDomains();
+    }
+    
     
     // Extract the domain from the email address
     const domain = email.split('@')[1].toLowerCase(); // Get the domain part of the email address and convert it to lowercase
@@ -28,7 +65,10 @@ export default async function disposableEmailDetector(email: string): Promise<bo
       console.error('index.json not found. Please create it with disposable domains.');
     } else if (error instanceof SyntaxError) {
       console.error('Invalid JSON format in index.json. Please correct the file.');
-    } else {
+    } else if (error instanceof ExternalSourceError) {
+        console.error(error.message);
+    }
+    else {
       console.error('Unexpected error:', error);
     }
     return false; 

--- a/test/usage.ts
+++ b/test/usage.ts
@@ -1,32 +1,67 @@
-import fs from 'fs/promises';
-import disposableEmailDetector from "../index"
-import path from 'path';
+import fs from "fs/promises";
+import disposableEmailDetector from "../index";
+import path from "path";
 
 // Load test emails from file
-const filePath: string = path.join(__dirname, './testEmails.txt');
+const filePath: string = path.join(__dirname, "./testEmails.txt");
 
 async function loadTestEmails(filePath: string): Promise<string[]> {
-  const rawData = await fs.readFile(filePath);
-  return rawData.toString().trim().split('\n');
+    const rawData = await fs.readFile(filePath);
+    return rawData.toString().trim().split("\n");
 }
 
 async function runTests() {
     try {
-  const testEmails = await loadTestEmails(filePath);
+        const testEmails = await loadTestEmails(filePath);
 
-  for (const email of testEmails) {
-    const isDisposable = await disposableEmailDetector(email);
-    console.log(email, '- Disposable:', isDisposable);
-  }
-    console.log('Test passed.');
+        for (const email of testEmails) {
+            const isDisposable = await disposableEmailDetector(email);
+            console.log(email, "- Disposable:", isDisposable);
+        }
+        console.log("Test passed.");
+    } catch (error: any) {
+        console.error("Unexpected error:", error);
+        console.error("Please check the file path and try again.");
+        console.error("Test failed.");
+    }
 }
-catch (error: any) {
-  console.error('Unexpected error:', error);
-  console.error('Please check the file path and try again.');
-  console.error('Test failed.');
+
+async function runTestsExternalGithub() {
+    try {
+        const testEmails = await loadTestEmails(filePath);
+
+        for (const email of testEmails) {
+            const isDisposable = await disposableEmailDetector(email, {
+                loadFromSource: { github: true },
+            });
+            console.log(email, "- Disposable:", isDisposable);
+        }
+        console.log("External: Github Test passed.");
+    } catch (error: any) {
+        console.error("Unexpected error:", error);
+        console.error("Please check the github repository for index.json and try again.");
+        console.error("Test failed.");
+    }
 }
 
+async function runTestsExternalURL() {
+    try {
+        const testEmails = await loadTestEmails(filePath);
 
+        for (const email of testEmails) {
+            const isDisposable = await disposableEmailDetector(email, {
+                loadFromSource: { url: "https://pastebin.com/raw/HL70DeZg" },
+            });
+            console.log(email, "- Disposable:", isDisposable);
+        }
+        console.log("External: URL Test passed.");
+    } catch (error: any) {
+        console.error("Unexpected error:", error);
+        console.error("Please check the URL and try again.");
+        console.error("Test failed.");
+    }
 }
 
 runTests();
+runTestsExternalGithub();
+runTestsExternalURL();


### PR DESCRIPTION
This gives the ability to load from external JSON's or directly from the Github main JSON itself. This enables users to get the latest `index.json`, without having to update the package just to get a new list of domains. Furthermore this enables users to load from an external source, such as a CDN within their organization. 

I have updated the test to reflect the new options field, and have also added a customer error class to enable clean catches. 